### PR TITLE
Prepare setup.py for SDIST building

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include pyagg/*.hxx
+graft agg-svn/agg-2.4/include
+graft agg-svn/agg-2.4/font_freetype
+graft agg-svn/agg-2.4/font_win32_tt

--- a/pyagg/setup.py
+++ b/pyagg/setup.py
@@ -156,8 +156,13 @@ def configuration(parent_package='', top_path=None):
         'extra_link_args': extra_link_args
     }
 
-    if cythonize is not None:
-        # Run Cython first
+    # Installing from an SDIST is special...
+    cpp_pyagg = op.join('pyagg', '_pyagg.cpp')
+    pyx_pyagg = op.join('pyagg', '_pyagg.pyx')
+    is_sdist = op.exists(cpp_pyagg) and not op.exists(pyx_pyagg)
+
+    # Run Cython first if this is a development version
+    if not is_sdist and cythonize is not None:
         cythonize(pyagg_cython_source, language='c++',
                   compile_time_env=cython_compile_env)
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ import sys
 from numpy.distutils.core import setup
 from numpy.distutils.misc_util import Configuration
 
-
 # Disable text rendering with this option
 if '--no-text-rendering' in sys.argv:
     del sys.argv[sys.argv.index('--no-text-rendering')]
@@ -56,14 +55,16 @@ setup(
     name='pyagg',
     configuration=configuration,
     license='MIT',
-    version='0.0.1',
+    version='0.1.0',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: C++',
+        'Programming Language :: Cython',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
         'Topic :: Software Development :: Libraries',
         'Operating System :: Microsoft :: Windows',


### PR DESCRIPTION
Running `python setup.py sdist` will now generate something which builds without requiring Cython to be installed on the target system.

Not entirely sure if the `--no-text-rendering` option will work with said SDIST.